### PR TITLE
A few workarounds on Mac OS X (10.10.3) and SciPy build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It is recommended that new users install the Anaconda Python distribution, which
 
 **If you are using Anaconda**, I recommend creating a new environment for the tutorial. You can do this by running:
 
-    conda create --name statcomp2 python=3
+    conda create --name statcomp2 python=3 scipy numpy matplotlib pandas ipython=3.0
     
 which will create an environment called `statcomp2` running Python 3. However, feel free to call it whatever you wish, or use an existing environment if you have one.
 
@@ -77,4 +77,12 @@ To check whether the required packages have been installed correctly and are fun
 
     python check_env.py
 
-          
+Note, if this fails with something like:
+
+    PyMC 3 is not installed. Please install via pip:
+    pip install -U git+git://github.com/pymc-devs/pymc3.git
+
+the fix is:
+	
+    pip install -U git+git://github.com/pymc-devs/pymc3.git
+

--- a/notebooks/1. Data Preparation.ipynb
+++ b/notebooks/1. Data Preparation.ipynb
@@ -663,7 +663,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -768,7 +768,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -994,7 +994,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1069,7 +1069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -1083,7 +1083,7 @@
        "Name: 3, dtype: object"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1108,7 +1108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -1126,7 +1126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
@@ -1134,7 +1134,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1199,7 +1199,7 @@
        "value           433            1130             754            555  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1217,7 +1217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -1225,7 +1225,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1300,7 +1300,7 @@
        "7       2   Bacteroidetes   555"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1323,7 +1323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "metadata": {
     "collapsed": false
    },
@@ -1342,7 +1342,7 @@
        "Name: value, dtype: object"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1361,7 +1361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -1380,7 +1380,7 @@
        "Name: value, dtype: object"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1399,7 +1399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false
    },
@@ -1407,7 +1407,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1482,7 +1482,7 @@
        "7       2   Bacteroidetes   555"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 33,
    "metadata": {
     "collapsed": false
    },
@@ -1508,7 +1508,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1583,7 +1583,7 @@
        "7       2   Bacteroidetes   555"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1604,7 +1604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false
    },
@@ -1622,7 +1622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 35,
    "metadata": {
     "collapsed": false
    },
@@ -1630,7 +1630,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1714,7 +1714,7 @@
        "7       2   Bacteroidetes   555  2013"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1733,7 +1733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 36,
    "metadata": {
     "collapsed": false
    },
@@ -1741,7 +1741,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1825,7 +1825,7 @@
        "7       2   Bacteroidetes   555  2013"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1837,7 +1837,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 37,
    "metadata": {
     "collapsed": false
    },
@@ -1848,7 +1848,7 @@
        "1"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1868,7 +1868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 38,
    "metadata": {
     "collapsed": false
    },
@@ -1885,7 +1885,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1898,7 +1898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 39,
    "metadata": {
     "collapsed": false
    },
@@ -1906,7 +1906,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -1999,7 +1999,7 @@
        "7       2   Bacteroidetes   555  2013        NaN"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2019,7 +2019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 40,
    "metadata": {
     "collapsed": false
    },
@@ -2031,11 +2031,11 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-42-360d03fdde9a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mmonth\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m'Jan'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Feb'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Mar'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Apr'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'month'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmonth\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/usr/local/lib/python3.4/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m   2119\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2120\u001b[0m             \u001b[0;31m# set column\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2121\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_set_item\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2122\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2123\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_setitem_slice\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.4/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_set_item\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m   2196\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2197\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_ensure_valid_index\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2198\u001b[0;31m         \u001b[0mvalue\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sanitize_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2199\u001b[0m         \u001b[0mNDFrame\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_set_item\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2200\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.4/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_sanitize_column\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m   2354\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2355\u001b[0m             \u001b[0;31m# turn me into an ndarray\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2356\u001b[0;31m             \u001b[0mvalue\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_sanitize_index\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2357\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mndarray\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIndex\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2358\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.4/site-packages/pandas/core/series.py\u001b[0m in \u001b[0;36m_sanitize_index\u001b[0;34m(data, index, copy)\u001b[0m\n\u001b[1;32m   2570\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2571\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2572\u001b[0;31m         raise ValueError('Length of values does not match length of '\n\u001b[0m\u001b[1;32m   2573\u001b[0m                          'index')\n\u001b[1;32m   2574\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-40-360d03fdde9a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mmonth\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m'Jan'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Feb'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Mar'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Apr'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'month'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmonth\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/serge/anaconda/envs/statcomp2/lib/python3.4/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m   2125\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2126\u001b[0m             \u001b[0;31m# set column\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2127\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_set_item\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2128\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2129\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_setitem_slice\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/serge/anaconda/envs/statcomp2/lib/python3.4/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_set_item\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m   2202\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2203\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_ensure_valid_index\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2204\u001b[0;31m         \u001b[0mvalue\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sanitize_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2205\u001b[0m         \u001b[0mNDFrame\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_set_item\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2206\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/serge/anaconda/envs/statcomp2/lib/python3.4/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_sanitize_column\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m   2360\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2361\u001b[0m             \u001b[0;31m# turn me into an ndarray\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2362\u001b[0;31m             \u001b[0mvalue\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_sanitize_index\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2363\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mndarray\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIndex\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2364\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/serge/anaconda/envs/statcomp2/lib/python3.4/site-packages/pandas/core/series.py\u001b[0m in \u001b[0;36m_sanitize_index\u001b[0;34m(data, index, copy)\u001b[0m\n\u001b[1;32m   2577\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2578\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2579\u001b[0;31m         raise ValueError('Length of values does not match length of '\n\u001b[0m\u001b[1;32m   2580\u001b[0m                          'index')\n\u001b[1;32m   2581\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mValueError\u001b[0m: Length of values does not match length of index"
      ]
     }
@@ -2047,7 +2047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 41,
    "metadata": {
     "collapsed": false
    },
@@ -2055,7 +2055,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2157,7 +2157,7 @@
        "7       2   Bacteroidetes   555  2013        NaN   Jan"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2177,7 +2177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 42,
    "metadata": {
     "collapsed": false
    },
@@ -2185,7 +2185,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2278,7 +2278,7 @@
        "7       2   Bacteroidetes   555  2013        NaN"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2298,7 +2298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 43,
    "metadata": {
     "collapsed": false
    },
@@ -2306,7 +2306,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2390,7 +2390,7 @@
        "7       2   Bacteroidetes   555  2013"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2408,7 +2408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 44,
    "metadata": {
     "collapsed": false
    },
@@ -2426,7 +2426,7 @@
        "       [2, 'Bacteroidetes', 555, 2013, nan]], dtype=object)"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2444,7 +2444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 45,
    "metadata": {
     "collapsed": false
    },
@@ -2457,7 +2457,7 @@
        "        [ 4.5,  3. ]]), dtype('float64'))"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2477,7 +2477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 46,
    "metadata": {
     "collapsed": false
    },
@@ -2488,7 +2488,7 @@
        "Int64Index([0, 1, 2, 3, 4, 5, 6, 7], dtype='int64')"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2506,7 +2506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 47,
    "metadata": {
     "collapsed": false
    },
@@ -2519,7 +2519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 48,
    "metadata": {
     "collapsed": false
    },
@@ -2527,7 +2527,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2620,7 +2620,7 @@
        "7        2   Bacteroidetes   555  2013        NaN"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2638,7 +2638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 49,
    "metadata": {
     "collapsed": false
    },
@@ -2654,7 +2654,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2676,7 +2676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 50,
    "metadata": {
     "collapsed": false
    },
@@ -2713,7 +2713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 51,
    "metadata": {
     "collapsed": false
    },
@@ -2748,7 +2748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 52,
    "metadata": {
     "collapsed": false
    },
@@ -2756,7 +2756,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2810,7 +2810,7 @@
        "Australia      41    18348078"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2855,7 +2855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 53,
    "metadata": {
     "collapsed": false
    },
@@ -2905,12 +2905,13 @@
        " 35  More on membership and enlargement              NaN                NaN NaN]"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "oecd_site=\"http://www.oecd.org/about/membersandpartners/list-oecd-member-countries.htm\"\n",
     "pd.read_html(oecd_site)"
    ]
   },
@@ -2925,7 +2926,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 54,
    "metadata": {
     "collapsed": false
    },
@@ -2933,7 +2934,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -2981,7 +2982,7 @@
        "4      CHILE         7 May 2010"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2993,7 +2994,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 55,
    "metadata": {
     "collapsed": false
    },
@@ -3039,7 +3040,7 @@
        "Name: year, dtype: float64"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3061,7 +3062,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 56,
    "metadata": {
     "collapsed": false
    },
@@ -3079,7 +3080,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 57,
    "metadata": {
     "collapsed": true
    },
@@ -3097,7 +3098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 58,
    "metadata": {
     "collapsed": false
    },
@@ -3105,7 +3106,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3173,7 +3174,7 @@
        "Australia      41    18348078   True       16.725035"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3195,7 +3196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 59,
    "metadata": {
     "collapsed": false
    },
@@ -3296,7 +3297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 60,
    "metadata": {
     "collapsed": false
    },
@@ -3304,7 +3305,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3364,7 +3365,7 @@
        "4  Firmicutes        5     831   8605"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3383,7 +3384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 61,
    "metadata": {
     "collapsed": false
    },
@@ -3391,7 +3392,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3451,7 +3452,7 @@
        "4  Firmicutes        8     173     33"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3469,7 +3470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 62,
    "metadata": {
     "collapsed": false
    },
@@ -3477,7 +3478,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3529,7 +3530,7 @@
        "3  Firmicutes        4     408   3946"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3549,7 +3550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 63,
    "metadata": {
     "collapsed": false
    },
@@ -3557,10 +3558,10 @@
     {
      "data": {
       "text/plain": [
-       "<pandas.io.parsers.TextFileReader at 0x10c16a3c8>"
+       "<pandas.io.parsers.TextFileReader at 0x10c960fd0>"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3583,7 +3584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 64,
    "metadata": {
     "collapsed": false
    },
@@ -3603,7 +3604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 65,
    "metadata": {
     "collapsed": false
    },
@@ -3611,7 +3612,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3668,7 +3669,7 @@
        "           5           831   8605"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3687,7 +3688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 66,
    "metadata": {
     "collapsed": false
    },
@@ -3700,7 +3701,7 @@
        "           names=['Taxon', 'Patient'])"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3725,7 +3726,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 67,
    "metadata": {
     "collapsed": false
    },
@@ -3738,7 +3739,7 @@
        "Name: (Firmicutes, 2), dtype: int64"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3756,7 +3757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 68,
    "metadata": {
     "collapsed": false
    },
@@ -3764,7 +3765,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3878,7 +3879,7 @@
        "15         1307     53"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3896,7 +3897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 69,
    "metadata": {
     "collapsed": false
    },
@@ -3904,7 +3905,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -3958,7 +3959,7 @@
        "Other              114    277"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3976,7 +3977,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 70,
    "metadata": {
     "collapsed": false
    },
@@ -3984,7 +3985,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4045,7 +4046,7 @@
        "5       Firmicutes     831   8605"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4067,7 +4068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 71,
    "metadata": {
     "collapsed": false
    },
@@ -4140,7 +4141,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4162,20 +4163,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 72,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<pandas.io.excel.ExcelFile at 0x10b7bb320>"
-      ]
-     },
-     "execution_count": 85,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "ImportError",
+     "evalue": "No module named 'xlrd'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-72-1c036069255a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmb_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mExcelFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'../data/microbiome/MID1.xls'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mmb_file\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/serge/anaconda/envs/statcomp2/lib/python3.4/site-packages/pandas/io/excel.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, io, **kwds)\u001b[0m\n\u001b[1;32m    167\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mio\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 169\u001b[0;31m         \u001b[0;32mimport\u001b[0m \u001b[0mxlrd\u001b[0m  \u001b[0;31m# throw an ImportError if we need to\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    170\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    171\u001b[0m         \u001b[0mver\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtuple\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mxlrd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__VERSION__\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msplit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\".\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: No module named 'xlrd'"
+     ]
     }
    ],
    "source": [
@@ -4192,65 +4195,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 73,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Taxon</th>\n",
-       "      <th>Count</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...</td>\n",
-       "      <td>7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Sulfoloba...</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Thermopro...</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Archaea \"Euryarchaeota\" \"Methanomicrobia\" Meth...</td>\n",
-       "      <td>7</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                               Taxon  Count\n",
-       "0  Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...      7\n",
-       "1  Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...      2\n",
-       "2  Archaea \"Crenarchaeota\" Thermoprotei Sulfoloba...      3\n",
-       "3  Archaea \"Crenarchaeota\" Thermoprotei Thermopro...      3\n",
-       "4  Archaea \"Euryarchaeota\" \"Methanomicrobia\" Meth...      7"
-      ]
-     },
-     "execution_count": 86,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'mb_file' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-73-b3e475aa4a62>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmb1\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmb_file\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Sheet 1\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mheader\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mmb1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolumns\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m\"Taxon\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"Count\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mmb1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhead\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'mb_file' is not defined"
+     ]
     }
    ],
    "source": [
@@ -4268,65 +4227,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 74,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>1</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Acidiloba...</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Acidiloba...</td>\n",
-       "      <td>14</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...</td>\n",
-       "      <td>23</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                   0   1\n",
-       "0  Archaea \"Crenarchaeota\" Thermoprotei Acidiloba...   2\n",
-       "1  Archaea \"Crenarchaeota\" Thermoprotei Acidiloba...  14\n",
-       "2  Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...  23\n",
-       "3  Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...   1\n",
-       "4  Archaea \"Crenarchaeota\" Thermoprotei Desulfuro...   2"
-      ]
-     },
-     "execution_count": 87,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "ImportError",
+     "evalue": "No module named 'xlrd'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-74-eadad525f0d6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmb2\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_excel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'../data/microbiome/MID2.xls'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msheetname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Sheet 1'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mheader\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mmb2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhead\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/serge/anaconda/envs/statcomp2/lib/python3.4/site-packages/pandas/io/excel.py\u001b[0m in \u001b[0;36mread_excel\u001b[0;34m(io, sheetname, **kwds)\u001b[0m\n\u001b[1;32m    149\u001b[0m     \u001b[0mengine\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mkwds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'engine'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    150\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 151\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mExcelFile\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mio\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mengine\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mengine\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msheetname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msheetname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    152\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    153\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/serge/anaconda/envs/statcomp2/lib/python3.4/site-packages/pandas/io/excel.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, io, **kwds)\u001b[0m\n\u001b[1;32m    167\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mio\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 169\u001b[0;31m         \u001b[0;32mimport\u001b[0m \u001b[0mxlrd\u001b[0m  \u001b[0;31m# throw an ImportError if we need to\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    170\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    171\u001b[0m         \u001b[0mver\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtuple\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mxlrd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__VERSION__\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msplit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\".\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: No module named 'xlrd'"
+     ]
     }
    ],
    "source": [
@@ -4347,7 +4264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 75,
    "metadata": {
     "collapsed": true
    },
@@ -4370,7 +4287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 76,
    "metadata": {
     "collapsed": false
    },
@@ -4383,7 +4300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 77,
    "metadata": {
     "collapsed": false
    },
@@ -4398,7 +4315,7 @@
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4409,7 +4326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 78,
    "metadata": {
     "collapsed": false
    },
@@ -4417,10 +4334,10 @@
     {
      "data": {
       "text/plain": [
-       "<sqlite3.Cursor at 0x1099b7f10>"
+       "<sqlite3.Cursor at 0x109da9f10>"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4431,7 +4348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 79,
    "metadata": {
     "collapsed": false
    },
@@ -4439,10 +4356,10 @@
     {
      "data": {
       "text/plain": [
-       "<sqlite3.Cursor at 0x1099b7f80>"
+       "<sqlite3.Cursor at 0x109d34180>"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4454,7 +4371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 80,
    "metadata": {
     "collapsed": true
    },
@@ -4472,7 +4389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 81,
    "metadata": {
     "collapsed": false
    },
@@ -4486,7 +4403,7 @@
        " ('Firmicutes', 4, 408, 3946)]"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4507,7 +4424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 82,
    "metadata": {
     "collapsed": false
    },
@@ -4515,7 +4432,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4567,7 +4484,7 @@
        "3  Firmicutes  4   408  3946"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4585,7 +4502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 83,
    "metadata": {
     "collapsed": false
    },
@@ -4599,7 +4516,7 @@
        " (3, 'stool', 'INTEGER', 0, None, 0)]"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4612,7 +4529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 84,
    "metadata": {
     "collapsed": false
    },
@@ -4620,7 +4537,7 @@
     {
      "data": {
       "text/html": [
-       "<div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -4672,7 +4589,7 @@
        "3  Firmicutes        4     408   3946"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7655,7 +7572,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,8 @@ jinja2
 tornado
 pyzmq
 jsonschema
+xlrd
+lxml
+beautifulsoup4
+html5lib
+


### PR DESCRIPTION
With the original instructions the compile of SciPy failed so I changed things to use the Anaconda package in building the env.

There were also a few packages missing that generated errors in the first notebook. I updated the requirements file to grab these. (I only had time to test on the first notebook, however.)

After changing the env build and the requirements I get:

```
python check_env.py
IPython 3.0.0
NumPy 1.9.2
pandas 0.16.2
SciPy 0.15.1
matplotlib 1.4.3
Theano 0.7.0
PyMC 3.0
scikit-learn 0.16.1
patsy 0.3.0

Everything's cool
```
