### PR TITLE
Update exercise_solutions.md

### DIFF
--- a/exercise_solutions.md
+++ b/exercise_solutions.md
@@ -15,7 +15,7 @@ mean_tissue = {chunk.Taxon[0]:chunk.Tissue.mean() for chunk in data_chunks}
 ### Filling missing values in microbiome data:
 
 ```python
-missing_sample.fillna(missing_sample.mean())
+missing_sample.fillna(missing_sample.groupby('Taxon').transform('mean'))
 ```
 
 # Density Estimation


### PR DESCRIPTION
Fix to fill missing values with the mean count from the corresponding species instead of using the full column mean.
